### PR TITLE
Add support for scoped validators

### DIFF
--- a/lib/valcro/runner.rb
+++ b/lib/valcro/runner.rb
@@ -15,5 +15,9 @@ module Valcro
         validator.call error_list
       end
     end
+
+    def clear!
+      @validators.clear
+    end
   end
 end

--- a/spec/valcro_spec.rb
+++ b/spec/valcro_spec.rb
@@ -68,6 +68,47 @@ describe Valcro, 'validators' do
   end
 end
 
+describe Valcro, 'reusable validators' do
+  class ScopedStatusFailValidator
+    def initialize(status)
+      @status = status
+    end
+    def call(errors)
+      errors.add(:status, 'big mistake') if @status == 'fail'
+    end
+  end
+
+  let(:test_class) do
+    Class.new do
+      include Valcro
+      attr_accessor :status
+      def status
+        @status ||= "fail"
+      end
+
+      validates_with { ScopedStatusFailValidator.new(status) }
+    end
+  end
+
+  it 'can be added validators' do
+    test_instance = test_class.new
+
+    test_instance.validate
+    expect(test_instance).not_to be_valid
+  end
+
+  it 'clears validations on subsequent runs' do
+    test_instance = test_class.new
+
+    test_instance.validate
+    expect(test_instance).not_to be_valid
+
+    test_instance.status = 'win'
+    test_instance.validate
+    expect(test_instance).to be_valid
+  end
+end
+
 describe Valcro, '#error_messages' do
   let(:test_class) do
     Class.new { include Valcro }


### PR DESCRIPTION
When sharing validators, often the interfaces provided by the objects being
validated are not uniform.

Furthermore, the validator API creates a layer of indirection when
testing the behaviour of the validator. Ideally, the validator could
be given any API to promote understandability and readability.

This change allows for validators to be dynamically created with any API
the developer desires.

An example showing the change in readability and flexibility:

``` ruby
class PolicyValidator
  attr_reader :desired_policy, :allowed_policies
  def initialize(desired_policy:, allowed_policies:)
    @desired_policy = desired_policy
    @allowed_policies = allowed_policies
  end

  def call(errors)
    unless allowed_policies.include?(desired_policy)
      errors.add(:desired_policy, "the desired policy is not allowed")
    end
  end
end

class AdminUserRequest
  include Valcro

  attr_accessor :desired_policy

  validates_with do
    PolicyValidator.new(desired_policy: desired_policy,
                        allowed_policies: ["admin"])
  end
end

class StandardUserRequest
  include Valcro

  attr_accessor :desired_policy, :policy_service

  validates_with do
    PolicyValidator.new(desired_policy: desired_policy,
                        allowed_policies: policy_service.call)
  end
end
```

This builds on #1, but can be reviewed and merged separately. 