### PR TITLE
allow not including the property to be configured on a per error basis

### DIFF
--- a/lib/valcro/error.rb
+++ b/lib/valcro/error.rb
@@ -2,13 +2,14 @@ module Valcro
   class Error
     attr_accessor :property, :message
 
-    def initialize(property, message)
+    def initialize(property, message, options={})
       @property = property
       @message  = message
+      @options = options
     end
 
     def to_s
-      if @property == :base
+      if @property == :base || @options[:include_property_in_to_s] == false
         message
       else
         "#{property.to_s} #{message}"

--- a/lib/valcro/error_list.rb
+++ b/lib/valcro/error_list.rb
@@ -9,8 +9,8 @@ module Valcro
       @errors << error
     end
 
-    def add(prop, message)
-      @errors << Valcro::Error.new(prop, message)
+    def add(prop, message, options={})
+      @errors << Valcro::Error.new(prop, message, options)
     end
 
     def [](prop)

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -18,8 +18,13 @@ describe Valcro::Error do
     expect(error.to_s).to eq('message')
   end
 
-  def create_error(prop = :prop, message = 'message')
-    Valcro::Error.new(prop, message)
+  it 'does not include property if told to ignore' do
+    error = create_error(:foo, 'message', include_property_in_to_s: false)
+    expect(error.to_s).to eq('message')
+  end
+
+  def create_error(prop = :prop, message = 'message', opts = {})
+    Valcro::Error.new(prop, message, opts)
   end
 end
 


### PR DESCRIPTION
currently valcro lets you specify a property which you don't want output in `to_s` by specifying the property as `:base`.

This PR lets you specify it when doing `errors.add`:

```false
errors.add(:walrus, "walruses cannot eat cheese!", include_property_in_to_s: false)
```