### PR TITLE
Allow validators to implement the .build method for easier testing

### DIFF
--- a/lib/valcro.rb
+++ b/lib/valcro.rb
@@ -20,9 +20,14 @@ module Valcro
   end
 
   def validate
-    errors.clear!
+    validation_runner.clear!
     self.class.validators.each do |validator_class|
-      validation_runner.add_validator validator_class.new(self)
+      validator = if validator_class.respond_to?(:build)
+                    validator_class.build(self)
+                  else
+                    validator_class.new(self)
+                  end
+      validation_runner.add_validator validator
     end
     self.class.validation_blocks.each do |validation_block|
       instance_eval(&validation_block)

--- a/lib/valcro/runner.rb
+++ b/lib/valcro/runner.rb
@@ -6,6 +6,11 @@ module Valcro
       @error_list = error_list
     end
 
+    def clear!
+      @validators.clear
+      @error_list.clear!
+    end
+
     def add_validator(validator)
       @validators << validator
     end


### PR DESCRIPTION
The validator API creates a layer of indirection when
testing the behaviour of the validator. Ideally, the validator could
be given any API to promote understandability and readability.

This change allows for validators to be dynamically created with any API
the developer desires.

An example showing the change in readability and flexibility:

``` ruby
class PolicyValidator
  def self.build(context)
    new(desired_policy: context.desired_policy,
        allowed_policies: context.policy_service.call)
  end

  attr_reader :desired_policy, :allowed_policies
  def initialize(desired_policy:, allowed_policies:)
    @desired_policy = desired_policy
    @allowed_policies = allowed_policies
  end

  def call(errors)
    unless allowed_policies.include?(desired_policy)
      errors.add(:desired_policy, "the desired policy is not allowed")
    end
  end
end

class StandardUserRequest
  include Valcro

  attr_accessor :desired_policy, :policy_service

  validates_with PolicyValidator
end
```

The spec might be something like this: 

``` ruby
it "works easily" do
  expect(PolicyValidator.new(desired_policy: "foo", allowed_policies: ["foo", "bar"]).to be_valid
end
```

This supercedes #2. 